### PR TITLE
Autoload with PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,36 @@
 {
-	"name": "hashids/hashids",
-	"type": "library",
-	"description": "Generate hashids like YouTube or Bitly from numbers to obfuscate your database primary ids, or navigate to the right shard.",
-	"keywords": ["hashids", "hashid", "hash", "ids", "youtube", "bitly", "encrypt", "decrypt", "obfuscate"],
-	"homepage": "http://hashids.org/php",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Ivan Akimov",
-			"email": "ivan@barreleye.com",
-			"homepage": "https://twitter.com/IvanAkimov"
-		}
-	],
-	"require": {
-		"php": ">=5.3.0"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "3.7.*"
-	},
-	"autoload": {
-		"psr-0": {
-			"Hashids": "lib/"
-		}
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "1.0-dev"
-		}
-	}
+    "name": "hashids/hashids",
+    "type": "library",
+    "description": "Generate hashids like YouTube or Bitly from numbers to obfuscate your database primary ids, or navigate to the right shard",
+    "keywords": ["hashids", "hashid", "hash", "ids", "youtube", "bitly", "encrypt", "decrypt", "obfuscate"],
+    "homepage": "http://hashids.org/php",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Ivan Akimov",
+            "email": "ivan@barreleye.com",
+            "homepage": "https://twitter.com/IvanAkimov"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
+    },
+    "autoload": {
+        "psr-4": {
+            "Hashids\\": "lib/Hashids/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Hashids\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Hashids Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-/* phpunit tests/HashidsTest.php */
+namespace Hashids\Tests;
 
-class HashidsTest extends \PHPUnit_Framework_TestCase {
+use Hashids\Hashids;
+use PHPUnit_Framework_TestCase;
+
+class HashidsTest extends PHPUnit_Framework_TestCase {
 	
 	private $hashids = null;
 	private $salt = 'this is my salt';
@@ -13,9 +16,9 @@ class HashidsTest extends \PHPUnit_Framework_TestCase {
 	
 	public function __construct() {
 		
-		$this->hashids = new Hashids\Hashids($this->salt);
-		$this->hashids_min_length = new Hashids\Hashids($this->salt, $this->min_hash_length);
-		$this->hashids_alphabet = new Hashids\Hashids($this->salt, 0, $this->custom_alphabet);
+		$this->hashids = new Hashids($this->salt);
+		$this->hashids_min_length = new Hashids($this->salt, $this->min_hash_length);
+		$this->hashids_alphabet = new Hashids($this->salt, 0, $this->custom_alphabet);
 		
 	}
 	


### PR DESCRIPTION
Since the PSR-0 is deprecated we should use to PSR-4 instead.

> Deprecated - As of 2014-10-21 PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative - <small>http://www.php-fig.org/psr/psr-0/</small>