### PR TITLE
Move default alphabet to constant

### DIFF
--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -103,8 +103,8 @@ class Hashids implements HashidsInterface
     public function __construct(
         $salt = static::DEFAULT_SALT,
         $minHashLength = static::DEFAULT_MIN_HASH_LENGTH,
-        $alphabet = static::DEFAULT_ALPHABET)
-    {
+        $alphabet = static::DEFAULT_ALPHABET
+    ) {
         $this->salt = $salt;
         $this->minHashLength = $minHashLength;
         $this->alphabet = implode('', array_unique(str_split($alphabet)));

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -34,6 +34,13 @@ class Hashids implements HashidsInterface
     const GUARD_DIV = 12;
 
     /**
+     * The default alphabet.
+     *
+     * @var string
+     */
+    const ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+
+    /**
      * The alphabet string.
      *
      * @var string
@@ -79,7 +86,7 @@ class Hashids implements HashidsInterface
      *
      * @return void
      */
-    public function __construct($salt = '', $minHashLength = 0, $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')
+    public function __construct($salt = '', $minHashLength = 0, $alphabet = Hashids::ALPHABET)
     {
         $this->salt = $salt;
         $this->minHashLength = $minHashLength;

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -101,9 +101,9 @@ class Hashids implements HashidsInterface
      * @return void
      */
     public function __construct(
-        $salt = Hashids::DEFAULT_SALT,
-        $minHashLength = Hashids::DEFAULT_MIN_HASH_LENGTH,
-        $alphabet = Hashids::DEFAULT_ALPHABET)
+        $salt = static::DEFAULT_SALT,
+        $minHashLength = static::DEFAULT_MIN_HASH_LENGTH,
+        $alphabet = static::DEFAULT_ALPHABET)
     {
         $this->salt = $salt;
         $this->minHashLength = $minHashLength;

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -101,9 +101,9 @@ class Hashids implements HashidsInterface
      * @return void
      */
     public function __construct(
-        $salt = static::DEFAULT_SALT,
-        $minHashLength = static::DEFAULT_MIN_HASH_LENGTH,
-        $alphabet = static::DEFAULT_ALPHABET
+        $salt = self::DEFAULT_SALT,
+        $minHashLength = self::DEFAULT_MIN_HASH_LENGTH,
+        $alphabet = self::DEFAULT_ALPHABET
     ) {
         $this->salt = $salt;
         $this->minHashLength = $minHashLength;

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -34,11 +34,25 @@ class Hashids implements HashidsInterface
     const GUARD_DIV = 12;
 
     /**
+     * The default salt.
+     *
+     * @var string
+     */
+    const DEFAULT_SALT = '';
+
+    /**
+     * The default mininum hash length.
+     *
+     * @var int
+     */
+    const DEFAULT_MIN_HASH_LENGTH = 0;
+
+    /**
      * The default alphabet.
      *
      * @var string
      */
-    const ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+    const DEFAULT_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
 
     /**
      * The alphabet string.
@@ -86,7 +100,10 @@ class Hashids implements HashidsInterface
      *
      * @return void
      */
-    public function __construct($salt = '', $minHashLength = 0, $alphabet = Hashids::ALPHABET)
+    public function __construct(
+        $salt = Hashids::DEFAULT_SALT,
+        $minHashLength = Hashids::DEFAULT_MIN_HASH_LENGTH,
+        $alphabet = Hashids::DEFAULT_ALPHABET)
     {
         $this->salt = $salt;
         $this->minHashLength = $minHashLength;


### PR DESCRIPTION
This will help developers of third party bridge-libraries to reuse default alphabet in their code (to pass to `Hashids` constructor).