### PR TITLE
Provide proper handling of arbitrary length integers

### DIFF
--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -153,7 +153,7 @@ class Hashids implements HashidsInterface
         $numbersHashInt = 0;
 
         foreach ($numbers as $i => $number) {
-            $numbersHashInt += Math::mod($number, ($i + 100));
+            $numbersHashInt += Math::intval(Math::mod($number, ($i + 100)));
         }
 
         $lottery = $ret = $alphabet[$numbersHashInt % strlen($alphabet)];
@@ -163,7 +163,7 @@ class Hashids implements HashidsInterface
 
             if ($i + 1 < $numbersSize) {
                 $number %= (ord($last) + $i);
-                $sepsIndex = Math::mod($number, strlen($this->seps));
+                $sepsIndex = Math::intval(Math::mod($number, strlen($this->seps)));
                 $ret .= $this->seps[$sepsIndex];
             }
         }
@@ -232,10 +232,10 @@ class Hashids implements HashidsInterface
             foreach ($hashArray as $subHash) {
                 $alphabet = $this->shuffle($alphabet, substr($lottery.$this->salt.$alphabet, 0, strlen($alphabet)));
                 $result = $this->unhash($subHash, $alphabet);
-                if(Math::comp($result, PHP_INT_MAX) < 0){
-                  $ret[] = Math::intval($result);
+                if (Math::comp($result, PHP_INT_MAX) <= 0) {
+                    $ret[] = Math::intval($result);
                 } else {
-                  $ret[] = $result;
+                    $ret[] = Math::strval($result);
                 }
             }
 
@@ -332,10 +332,10 @@ class Hashids implements HashidsInterface
         $alphabetLength = strlen($alphabet);
 
         do {
-            $hash = $alphabet[Math::mod($input, $alphabetLength)].$hash;
+            $hash = $alphabet[Math::intval(Math::mod($input, $alphabetLength))].$hash;
 
             $input = Math::divide($input, $alphabetLength);
-        } while ($input);
+        } while (Math::comp(0, $input) != 0);
 
         return $hash;
     }

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -143,7 +143,7 @@ class Hashids implements HashidsInterface
         foreach ($numbers as $number) {
             $isNumber = ctype_digit((string) $number);
 
-            if (!$isNumber || $number < 0 || $number > PHP_INT_MAX) {
+            if (!$isNumber) {
                 return $ret;
             }
         }
@@ -153,7 +153,7 @@ class Hashids implements HashidsInterface
         $numbersHashInt = 0;
 
         foreach ($numbers as $i => $number) {
-            $numbersHashInt += ($number % ($i + 100));
+            $numbersHashInt += Math::mod($number, ($i + 100));
         }
 
         $lottery = $ret = $alphabet[$numbersHashInt % strlen($alphabet)];
@@ -163,7 +163,7 @@ class Hashids implements HashidsInterface
 
             if ($i + 1 < $numbersSize) {
                 $number %= (ord($last) + $i);
-                $sepsIndex = $number % strlen($this->seps);
+                $sepsIndex = Math::mod($number, strlen($this->seps));
                 $ret .= $this->seps[$sepsIndex];
             }
         }
@@ -231,7 +231,12 @@ class Hashids implements HashidsInterface
 
             foreach ($hashArray as $subHash) {
                 $alphabet = $this->shuffle($alphabet, substr($lottery.$this->salt.$alphabet, 0, strlen($alphabet)));
-                $ret[] = (int) $this->unhash($subHash, $alphabet);
+                $result = $this->unhash($subHash, $alphabet);
+                if(Math::comp($result, PHP_INT_MAX) < 0){
+                  $ret[] = Math::intval($result);
+                } else {
+                  $ret[] = $result;
+                }
             }
 
             if ($this->encode($ret) != $hash) {
@@ -327,7 +332,7 @@ class Hashids implements HashidsInterface
         $alphabetLength = strlen($alphabet);
 
         do {
-            $hash = $alphabet[$input % $alphabetLength].$hash;
+            $hash = $alphabet[Math::mod($input, $alphabetLength)].$hash;
 
             $input = Math::divide($input, $alphabetLength);
         } while ($input);
@@ -355,7 +360,7 @@ class Hashids implements HashidsInterface
             foreach ($inputChars as $i => $char) {
                 $pos = strpos($alphabet, $char);
 
-                $number = Math::add($number, $pos * Math::pow($alphabetLength, ($inputLength - $i - 1)));
+                $number = Math::add($number, Math::multiply($pos, Math::pow($alphabetLength, ($inputLength - $i - 1))));
             }
         }
 

--- a/src/Math.php
+++ b/src/Math.php
@@ -19,53 +19,121 @@ namespace Hashids;
 class Math
 {
     /**
-     * Add two arbitrary precision numbers.
+     * Add two arbitrary-length integers.
      *
-     * @param int $a
-     * @param int $b
+     * @param string $a
+     * @param string $b
      *
-     * @return int
+     * @return string
      */
     public static function add($a, $b)
     {
         if (function_exists('gmp_add')) {
-            return gmp_intval(gmp_add($a, $b));
+            return gmp_add($a, $b);
         }
 
-        return intval(bcadd($a, $b));
+        return bcadd($a, $b);
     }
 
     /**
-     * Divide two arbitrary precision numbers.
+     * Multiply two arbitrary-length integers
      *
-     * @param int $a
-     * @param int $b
+     * @param string $base
+     * @param string $exp
      *
-     * @return int
+     * @return string
+     */
+    public static function multiply($a, $b)
+    {
+        if (function_exists('gmp_mul')) {
+            return gmp_mul($a, $b);
+        }
+
+        return bcmul($a, $b);
+    }
+
+    /**
+     * Divide two arbitrary-length integers.
+     *
+     * @param string $a
+     * @param string $b
+     *
+     * @return string
      */
     public static function divide($a, $b)
     {
         if (function_exists('gmp_div_q')) {
-            return gmp_intval(gmp_div_q($a, $b));
+            return gmp_div_q($a, $b);
         }
 
-        return intval(bcdiv($a, $b));
+        return bcdiv($a, $b);
     }
 
     /**
-     * Raise number into power.
+     * Raise arbitrary-length integer into power.
      *
-     * @param int $base
-     * @param int $exp
+     * @param string $base
+     * @param string $exp
      *
-     * @return int
+     * @return string
      */
     public static function pow($base, $exp)
     {
         if (function_exists('gmp_pow')) {
-            return gmp_intval(gmp_pow($base, $exp));
+            return gmp_pow($base, $exp);
         }
 
-        return pow($base, $exp);
+        return bcpow($base, $exp);
     }
+
+    /**
+     * Compute arbitrary-length integer modulo.
+     *
+     * @param string $n
+     * @param string $d
+     *
+     * @return string
+     */
+    public static function mod($n, $d)
+    {
+        if (function_exists('gmp_mod')) {
+            return gmp_mod($n, $d);
+        }
+
+        return bcmod($n, $d);
+    }
+
+    /**
+     * Compares two arbitrary-length integer modulo.
+     *
+     * @param string $a
+     * @param string $b
+     *
+     * @return int
+     */
+    public static function comp($a, $b)
+    {
+        if (function_exists('gmp_cmp')) {
+            return gmp_cmp($a, $b);
+        }
+
+        return bccomp($a, $b);
+    }
+
+    /**
+     * Converts arbitrary-length integer to PHP integer.
+     *
+     * @param string $a
+     *
+     * @return int
+     */
+    public static function intval($a)
+    {
+        if (function_exists('gmp_intval')) {
+            return gmp_intval($a);
+        }
+
+        return intval($a);
+    }
+
 }

--- a/src/Math.php
+++ b/src/Math.php
@@ -36,10 +36,10 @@ class Math
     }
 
     /**
-     * Multiply two arbitrary-length integers
+     * Multiply two arbitrary-length integers.
      *
-     * @param string $base
-     * @param string $exp
+     * @param string $a
+     * @param string $b
      *
      * @return string
      */
@@ -136,4 +136,35 @@ class Math
         return intval($a);
     }
 
+    /**
+     * Converts arbitrary-length integer to PHP string.
+     *
+     * @param string $a
+     *
+     * @return string
+     */
+    public static function strval($a)
+    {
+        if (function_exists('gmp_strval')) {
+            return gmp_strval($a);
+        }
+
+        return $a;
+    }
+
+    /**
+     * Converts PHP integer to arbitrary-length integer.
+     *
+     * @param int $a
+     *
+     * @return string
+     */
+    public static function get($a)
+    {
+        if (function_exists('gmp_init')) {
+            return gmp_init($a);
+        }
+
+        return $a;
+    }
 }

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -250,4 +250,34 @@ class HashidsTest extends AbstractTestCase
             $this->assertLessThanOrEqual(strlen($encodedId), $minLength);
         }
     }
+
+
+    public function bigNumberDataProvider(){
+        return [
+            [2147483647, 'ykJWW1g'], //max 32-bit signed integer
+            [4294967295, 'j4r6j8Y'], // max 32-bit unsigned integer
+            ['9223372036854775807', 'jvNx4BjM5KYjv'], // max 64-bit signed integer
+            ['18446744073709551615', 'zXVjmzBamYlqX'], // max 64-bit unsigned integer
+        ];
+    }
+
+    /**
+   * @dataProvider bigNumberDataProvider
+   */
+    public function testBigNumberEncode($number, $hash)
+    {
+        $hashids = new Hashids('this is my salt');
+        $encoded = $hashids->encode($number);
+        $this->assertEquals($hash, $encoded);
+    }
+
+    /**
+   * @dataProvider bigNumberDataProvider
+   */
+    public function testBigNumberDecode($number, $hash)
+    {
+        $hashids = new Hashids('this is my salt');
+        $decoded = $hashids->decode($hash);
+        $this->assertEquals($number, $decoded[0]);
+    }
 }

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -251,8 +251,8 @@ class HashidsTest extends AbstractTestCase
         }
     }
 
-
-    public function bigNumberDataProvider(){
+    public function bigNumberDataProvider()
+    {
         return [
             [2147483647, 'ykJWW1g'], //max 32-bit signed integer
             [4294967295, 'j4r6j8Y'], // max 32-bit unsigned integer
@@ -262,8 +262,8 @@ class HashidsTest extends AbstractTestCase
     }
 
     /**
-   * @dataProvider bigNumberDataProvider
-   */
+     * @dataProvider bigNumberDataProvider
+     */
     public function testBigNumberEncode($number, $hash)
     {
         $hashids = new Hashids('this is my salt');
@@ -272,8 +272,8 @@ class HashidsTest extends AbstractTestCase
     }
 
     /**
-   * @dataProvider bigNumberDataProvider
-   */
+     * @dataProvider bigNumberDataProvider
+     */
     public function testBigNumberDecode($number, $hash)
     {
         $hashids = new Hashids('this is my salt');

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -39,4 +39,21 @@ class MathTest extends AbstractTestCase
     {
         $this->assertEquals(16, Math::pow(4, 2));
     }
+
+    public function testComp()
+    {
+        $this->assertGreaterThan(0, Math::comp('18446744073709551615', '9223372036854775807'));
+        $this->assertLessThan(0, Math::comp('9223372036854775807', '18446744073709551615'));
+        $this->assertEquals(0, Math::comp('9223372036854775807', '9223372036854775807'));
+    }
+
+    public function testMod()
+    {
+        $this->assertEquals(15, Math::mod('18446744073709551615', '100'));
+    }
+
+    public function testIntval()
+    {
+        $this->assertSame(9223372036854775807, Math::intval('9223372036854775807'));
+    }
 }

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -22,19 +22,21 @@ class MathTest extends AbstractTestCase
 {
     public function testAdd()
     {
-        $this->assertSame(3, Math::add(1, 2));
-        $this->assertTrue(is_int(Math::add(1, 2)));
+        $this->assertEquals(3, Math::add(1, 2));
+    }
+
+    public function testMultiply()
+    {
+        $this->assertEquals(12, Math::multiply(2, 6));
     }
 
     public function testDivide()
     {
-        $this->assertSame(2, Math::divide(4, 2));
-        $this->assertTrue(is_int(Math::divide(4, 2)));
+        $this->assertEquals(2, Math::divide(4, 2));
     }
 
     public function testPow()
     {
-        $this->assertSame(16, Math::pow(4, 2));
-        $this->assertTrue(is_int(Math::pow(4, 2)));
+        $this->assertEquals(16, Math::pow(4, 2));
     }
 }

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -22,22 +22,22 @@ class MathTest extends AbstractTestCase
 {
     public function testAdd()
     {
-        $this->assertEquals(3, Math::add(1, 2));
+        $this->assertEquals(Math::get(3), Math::add(1, 2));
     }
 
     public function testMultiply()
     {
-        $this->assertEquals(12, Math::multiply(2, 6));
+        $this->assertEquals(Math::get(12), Math::multiply(2, 6));
     }
 
     public function testDivide()
     {
-        $this->assertEquals(2, Math::divide(4, 2));
+        $this->assertEquals(Math::get(2), Math::divide(4, 2));
     }
 
     public function testPow()
     {
-        $this->assertEquals(16, Math::pow(4, 2));
+        $this->assertEquals(Math::get(16), Math::pow(4, 2));
     }
 
     public function testComp()
@@ -49,11 +49,16 @@ class MathTest extends AbstractTestCase
 
     public function testMod()
     {
-        $this->assertEquals(15, Math::mod('18446744073709551615', '100'));
+        $this->assertEquals(Math::get(15), Math::mod('18446744073709551615', '100'));
     }
 
     public function testIntval()
     {
         $this->assertSame(9223372036854775807, Math::intval('9223372036854775807'));
+    }
+
+    public function testStrval()
+    {
+        $this->assertSame('18446744073709551615', Math::strval(Math::add('0', '18446744073709551615')));
     }
 }


### PR DESCRIPTION
Current version of library silently fails on numbers bigger than 32^2-1, but does require libraries which are needed only in this case.

Results of encode() and decode() in this pull request are consistent with [davidaurelio/hashids-python](https://github.com/davidaurelio/hashids-python). encodeHex() and decodeHex() is still missing, as dechex/hexdec needs to be reimplemented.