### PR TITLE
Use variable-length argument list

### DIFF
--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -125,14 +125,15 @@ class Hashids implements HashidsInterface
     /**
      * Encode parameters to generate a hash.
      *
+     * @param mixed $numbers
+     *
      * @return string
      */
-    public function encode()
+    public function encode(...$numbers)
     {
         $ret = '';
-        $numbers = func_get_args();
 
-        if (func_num_args() == 1 && is_array(func_get_arg(0))) {
+        if (1 === count($numbers) && is_array($numbers[0])) {
             $numbers = $numbers[0];
         }
 

--- a/src/HashidsInterface.php
+++ b/src/HashidsInterface.php
@@ -22,9 +22,11 @@ interface HashidsInterface
     /**
      * Encode parameters to generate a hash.
      *
+     * @param mixed $numbers
+     *
      * @return string
      */
-    public function encode();
+    public function encode(...$numbers);
 
     /**
      * Decode a hash to the original parameter values.


### PR DESCRIPTION
[Variadic functions](http://php.net/manual/en/functions.arguments.php#functions.variable-arg-list) are IDE-friendlier then using `func_get_args()` and are available in the lowest supported PHP version.
Let's use it (and silence the complaints) :)