### PR TITLE
Remove BC Math Requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ php:
 
 env:
   matrix:
-    - PHP_OPTIONS="-d disable_functions=bcadd,bccomp,bcdiv,bcmod,bcmul,bcpow,bcpowmod,bcscale,bcsqrt,bcsub"
-    - PHP_OPTIONS="-d disable_functions=gmp_abs,gmp_add,gmp_and,gmp_clrbit,gmp_cmp,gmp_com,gmp_div,gmp_divexact,gmp_div_q,gmp_div_qr,gmp_div_r,gmp_export,gmp_fact,gmp_gcd,gmp_gcdext,gmp_hamdist,gmp_import,gmp_init,gmp_intval,gmp_invert,gmp_jacobi,gmp_legendre,gmp_mod,gmp_mul,gmp_neg,gmp_nextprime,gmp_or,gmp_perfect_square,gmp_popcount,gmp_pow,gmp_powm,gmp_prob_prime,gmp_random,gmp_random_bits,gmp_random_range,gmp_random_seed,gmp_root,gmp_rootrem,gmp_scan0,gmp_scan1,gmp_setbit,gmp_sign,gmp_sqrt,gmp_sqrtrem,gmp_strval,gmp_sub,gmp_testbit,gmp_xor"
+    - OPTIONS="-d disable_functions=bcadd,bccomp,bcdiv,bcmod,bcmul,bcpow,bcpowmod,bcscale,bcsqrt,bcsub" SUITE=standard
+    - OPTIONS="-d disable_functions=gmp_abs,gmp_add,gmp_and,gmp_clrbit,gmp_cmp,gmp_com,gmp_div,gmp_divexact,gmp_div_q,gmp_div_qr,gmp_div_r,gmp_export,gmp_fact,gmp_gcd,gmp_gcdext,gmp_hamdist,gmp_import,gmp_init,gmp_intval,gmp_invert,gmp_jacobi,gmp_legendre,gmp_mod,gmp_mul,gmp_neg,gmp_nextprime,gmp_or,gmp_perfect_square,gmp_popcount,gmp_pow,gmp_powm,gmp_prob_prime,gmp_random,gmp_random_bits,gmp_random_range,gmp_random_seed,gmp_root,gmp_rootrem,gmp_scan0,gmp_scan1,gmp_setbit,gmp_sign,gmp_sqrt,gmp_sqrtrem,gmp_strval,gmp_sub,gmp_testbit,gmp_xor" SUITE=standard
+    - OPTIONS="-d disable_functions=bcadd,bccomp,bcdiv,bcmod,bcmul,bcpow,bcpowmod,bcscale,bcsqrt,bcsub,gmp_abs,gmp_add,gmp_and,gmp_clrbit,gmp_cmp,gmp_com,gmp_div,gmp_divexact,gmp_div_q,gmp_div_qr,gmp_div_r,gmp_export,gmp_fact,gmp_gcd,gmp_gcdext,gmp_hamdist,gmp_import,gmp_init,gmp_intval,gmp_invert,gmp_jacobi,gmp_legendre,gmp_mod,gmp_mul,gmp_neg,gmp_nextprime,gmp_or,gmp_perfect_square,gmp_popcount,gmp_pow,gmp_powm,gmp_prob_prime,gmp_random,gmp_random_bits,gmp_random_range,gmp_random_seed,gmp_root,gmp_rootrem,gmp_scan0,gmp_scan1,gmp_setbit,gmp_sign,gmp_sqrt,gmp_sqrtrem,gmp_strval,gmp_sub,gmp_testbit,gmp_xor" SUITE=functionless
 
 sudo: false
 
@@ -17,7 +18,7 @@ install:
   - travis_retry composer install --no-interaction
 
 script:
-  - php $PHP_OPTIONS vendor/bin/phpunit --coverage-clover clover.xml
+  - php $OPTIONS vendor/bin/phpunit --testsuite $SUITE --coverage-clover clover.xml
 
 after_script:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $hashids = new Hashids();
 $hashids->encode(1);
 ```
 
-> **Note:** Hashids requires the [BCMath](https://secure.php.net/manual/en/book.bc.php) extension in order to work. Optionally you can use the [GMP](https://secure.php.net/manual/en/book.gmp.php) extension.
+> **Note:** Hashids requires either the [BC Math](https://secure.php.net/manual/en/book.bc.php) or [GMP](https://secure.php.net/manual/en/book.gmp.php) extension in order to work.
 
 ## Quick Example
 

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,10 @@
         }
     ],
     "require": {
-        "php": "^5.6.4 || ^7.0",
-        "ext-bcmath": "*"
+        "php": "^5.6.4 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "phpunit/phpunit": "^5.7 || ^6.3"
     },
     "autoload": {
         "psr-4": {
@@ -41,6 +40,10 @@
             "dev-master": "2.1-dev"
         }
     },
+    "suggest": {
+       "ext-bcmatch": "Required to use BC Math arbitrary precision mathematics (*).",
+       "ext-gmp": "Required to use GNU multiple precision mathematics (*)."
+     },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,8 +16,12 @@
          verbose="true"
 >
     <testsuites>
-        <testsuite name="Hashids Test Suite">
-            <directory suffix="Test.php">./tests</directory>
+        <testsuite name="standard">
+            <file>tests/HashidsTest.php</file>
+            <file>tests/MathTest.php</file>
+        </testsuite>
+        <testsuite name="functionless">
+            <file>tests/RuntimeExceptionTest.php</file>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/Math.php
+++ b/src/Math.php
@@ -11,10 +11,13 @@
 
 namespace Hashids;
 
+use RuntimeException;
+
 /**
  * This is the math class.
  *
  * @author Vincent Klaiber <hello@vinkla.com>
+ * @author Jakub Kramarz <lenwe@lenwe.net>
  */
 class Math
 {
@@ -24,6 +27,8 @@ class Math
      * @param string $a
      * @param string $b
      *
+     * @throws \RuntimeException
+     *
      * @return string
      */
     public static function add($a, $b)
@@ -32,7 +37,11 @@ class Math
             return gmp_add($a, $b);
         }
 
-        return bcadd($a, $b, 0);
+        if (function_exists('bcadd')) {
+            return bcadd($a, $b, 0);
+        }
+
+        throw new RuntimeException('Missing BC Math or GMP extension.');
     }
 
     /**
@@ -40,6 +49,8 @@ class Math
      *
      * @param string $a
      * @param string $b
+     *
+     * @throws \RuntimeException
      *
      * @return string
      */
@@ -49,7 +60,11 @@ class Math
             return gmp_mul($a, $b);
         }
 
-        return bcmul($a, $b, 0);
+        if (function_exists('bcmul')) {
+            return bcmul($a, $b, 0);
+        }
+
+        throw new RuntimeException('Missing BC Math or GMP extension.');
     }
 
     /**
@@ -57,6 +72,8 @@ class Math
      *
      * @param string $a
      * @param string $b
+     *
+     * @throws \RuntimeException
      *
      * @return string
      */
@@ -66,7 +83,11 @@ class Math
             return gmp_div_q($a, $b);
         }
 
-        return bcdiv($a, $b, 0);
+        if (function_exists('bcdiv')) {
+            return bcdiv($a, $b, 0);
+        }
+
+        throw new RuntimeException('Missing BC Math or GMP extension.');
     }
 
     /**
@@ -74,6 +95,8 @@ class Math
      *
      * @param string $n
      * @param string $d
+     *
+     * @throws \RuntimeException
      *
      * @return string
      */
@@ -83,7 +106,11 @@ class Math
             return gmp_mod($n, $d);
         }
 
-        return bcmod($n, $d);
+        if (function_exists('bcmod')) {
+            return bcmod($n, $d);
+        }
+
+        throw new RuntimeException('Missing BC Math or GMP extension.');
     }
 
     /**
@@ -91,6 +118,8 @@ class Math
      *
      * @param string $a
      * @param string $b
+     *
+     * @throws \RuntimeException
      *
      * @return bool
      */
@@ -100,7 +129,11 @@ class Math
             return gmp_cmp($a, $b) > 0;
         }
 
-        return bccomp($a, $b, 0) > 0;
+        if (function_exists('bccomp')) {
+            return bccomp($a, $b, 0) > 0;
+        }
+
+        throw new RuntimeException('Missing BC Math or GMP extension.');
     }
 
     /**

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * This file is part of Hashids.
- *
- * (c) Ivan Akimov <ivan@barreleye.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
+* This file is part of Hashids.
+*
+* (c) Ivan Akimov <ivan@barreleye.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
 
 namespace Hashids\Tests;
 

--- a/tests/RuntimeExceptionTest.php
+++ b/tests/RuntimeExceptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+* This file is part of Hashids.
+*
+* (c) Ivan Akimov <ivan@barreleye.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Hashids\Tests;
+
+use Hashids\Math;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * This is the runtime exception test class.
+ *
+ * @author Vincent Klaiber <hello@vinkla.com>
+ */
+class RuntimeExceptionTest extends TestCase
+{
+    public function testAdd()
+    {
+        $this->expectException(RuntimeException::class);
+
+        Math::add(1, 2);
+    }
+
+    public function testMultiply()
+    {
+        $this->expectException(RuntimeException::class);
+
+        Math::multiply(1, 2);
+    }
+
+    public function testDivide()
+    {
+        $this->expectException(RuntimeException::class);
+
+        Math::divide(1, 2);
+    }
+
+    public function testGreaterThan()
+    {
+        $this->expectException(RuntimeException::class);
+
+        Math::greaterThan('1', '2');
+    }
+
+    public function testMod()
+    {
+        $this->expectException(RuntimeException::class);
+
+        Math::mod('1', '2');
+    }
+}


### PR DESCRIPTION
This pull request will remove the `ext-bcmath` requirement from the `composer.json` file. If you don't have installed BC Math but GMP installed you can't currently install this package. This pull request will solve that issue.

This is still work in progress. The tests should pass and we want to keep our coverage at 100%.