### PR TITLE
Store shuffled alphabets so that they don't have to be calculated again.

### DIFF
--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -307,7 +307,8 @@ class Hashids implements HashidsInterface
      */
     protected function shuffle($alphabet, $salt)
     {
-        $key = $alphabet . ' ' . $salt;
+        $key = $alphabet.' '.$salt;
+        
         if (isset($this->shuffledAlphabets[$key])) {
             return $this->shuffledAlphabets[$key];
         }

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -308,7 +308,7 @@ class Hashids implements HashidsInterface
     protected function shuffle($alphabet, $salt)
     {
         $key = $alphabet.' '.$salt;
-        
+
         if (isset($this->shuffledAlphabets[$key])) {
             return $this->shuffledAlphabets[$key];
         }

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -41,6 +41,13 @@ class Hashids implements HashidsInterface
     protected $alphabet;
 
     /**
+     * Shuffled alphabets, referenced by alphabet and salt.
+     *
+     * @var array
+     */
+    protected $shuffledAlphabets;
+
+    /**
      * The seps string.
      *
      * @var string
@@ -300,6 +307,11 @@ class Hashids implements HashidsInterface
      */
     protected function shuffle($alphabet, $salt)
     {
+        $key = $alphabet . ' ' . $salt;
+        if (isset($this->shuffledAlphabets[$key])) {
+            return $this->shuffledAlphabets[$key];
+        }
+
         $saltLength = strlen($salt);
 
         if (!$saltLength) {
@@ -315,6 +327,8 @@ class Hashids implements HashidsInterface
             $alphabet[$j] = $alphabet[$i];
             $alphabet[$i] = $temp;
         }
+
+        $this->shuffledAlphabets[$key] = $alphabet;
 
         return $alphabet;
     }


### PR DESCRIPTION
This changes the Hashids::bench function so that it will store a shuffled alphabet once it's been created. This increases the performance of the function, especially when calculating large numbers of hashes.

Here are a couple of blackfire.io profiles for [encoding 50,000 hashes](https://gist.github.com/jwpage/ad9e1461b2f78b0c64247a6292f490f6).

* Before:  [8.99s](https://blackfire.io/profiles/98fc73c7-c002-45b4-98c9-a3eee55a5d50/graph)
* After: [4.96s](https://blackfire.io/profiles/290a3716-56dc-44b7-88eb-be2891d3c9d5/graph)