### PR TITLE
Added global namespace to RuntimeException

### DIFF
--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -110,7 +110,7 @@ class Hashids implements HashidsInterface
         } elseif (extension_loaded('bcmath')) {
             $this->math = new Bc();
         } else {
-            throw new RuntimeException('Missing BC Math or GMP extension.');
+            throw new \RuntimeException('Missing BC Math or GMP extension.');
         }
         // @codeCoverageIgnoreEnd
 


### PR DESCRIPTION
This fixes an exception with throwing an exception during the check for valid math extensions.